### PR TITLE
Add Claude support via provider abstraction layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI Impact Tracker is a Chrome/Firefox browser extension (Manifest V3) that estimates the environmental impact of ChatGPT conversations. It tracks messages, estimates token counts, calculates energy consumption using the EcoLogits methodology, and displays relatable equivalents (YouTube streaming time, light bulb runtime, phone charges, elevator floors).
+AI Impact Tracker is a Chrome/Firefox browser extension (Manifest V3) that estimates the environmental impact of AI chat conversations (ChatGPT and Claude). It tracks messages, estimates token counts, calculates energy consumption using the EcoLogits methodology with provider-specific model parameters, and displays relatable equivalents (YouTube streaming time, light bulb runtime, phone charges, elevator floors).
 
 ## Commands
 
@@ -16,6 +16,7 @@ npm test
 node test-refactoring.js    # Tests energy-calculator.js shared module
 node verify-fix.js          # Tests energy calculation correctness
 node test-global-scale.js   # Tests global scale comparison feature
+node test-providers.js      # Tests provider abstraction layer
 ```
 
 There is no build step — the extension loads raw JS files directly. To test in browser, load as an unpacked extension via `chrome://extensions` with Developer Mode enabled.
@@ -34,26 +35,34 @@ Each file checks its environment (`typeof window`, `typeof module`) to export ap
 
 ### Core Files
 
-- **energy-calculator.js** — Shared energy/emissions calculation module implementing EcoLogits v0.9.x methodology. All constants (GPT-5 model params, EcoLogits coefficients) live here.
-- **content.js** — Content script injected into ChatGPT pages. Intercepts fetch requests (SSE streams), observes DOM mutations, extracts user/assistant messages, calculates energy per exchange, persists to `chrome.storage.local`.
-- **popup.js** — Popup UI logic. Reads logs from storage, displays today/lifetime stats, recalculates stored logs on load to match current methodology, shows environmental equivalents.
-- **global-scale.js** — Scales user's daily average to 900M ChatGPT WAU and compares against reference dataset of countries/cities/continents annual electricity consumption.
+- **providers.js** — Provider abstraction layer defining AI platform configurations (ChatGPT, Claude). Each provider specifies DOM selectors, token estimation logic, model parameters, and API patterns. Makes it easy to add new AI platforms.
+- **energy-calculator.js** — Shared energy/emissions calculation module implementing EcoLogits v0.9.x methodology. Takes provider-specific model params to calculate energy consumption.
+- **content.js** — Content script injected into supported AI chat pages. Detects active provider, observes DOM mutations, extracts user/assistant messages, calculates energy per exchange using provider's model params, persists to `chrome.storage.local`.
+- **popup.js** — Popup UI logic. Reads logs from storage, displays today/lifetime stats, recalculates stored logs using provider-specific params, shows environmental equivalents.
+- **global-scale.js** — Scales user's daily average to 900M AI chat WAU and compares against reference dataset of countries/cities/continents annual electricity consumption.
 - **background.js** — Minimal service worker handling install/update lifecycle and storage initialization.
 - **popup.html** — Popup UI markup.
 
 ### Data Flow
 
-1. `content.js` intercepts ChatGPT API responses and observes DOM for message pairs
-2. Token count estimated as `Math.ceil(text.length / 4)`
-3. `calculateEnergyAndEmissions()` from `energy-calculator.js` computes Wh and CO2
-4. Logs stored in `chrome.storage.local` under key `chatgptLogs`
-5. `popup.js` reads logs from storage, recalculates with current formula, computes equivalents, and renders stats
+1. `content.js` detects active provider (ChatGPT or Claude) via `providers.js`
+2. Observes DOM for message pairs using provider-specific selectors
+3. Token count estimated as `Math.ceil(text.length / 4)` using provider's `estimateTokens()` function
+4. `calculateEnergyAndEmissions()` from `energy-calculator.js` computes Wh and CO2 using provider's model params
+5. Logs stored in `chrome.storage.local` under key `aiChatLogs` (includes provider ID)
+6. `popup.js` reads logs from storage, recalculates with current formula using provider-specific params, computes equivalents, and renders stats
 
 ### Chrome Extension Permissions
 
 - `storage` — for persisting conversation logs locally
-- `host_permissions` — `https://chatgpt.com/*` and `https://chat.openai.com/*`
+- `host_permissions` —
+  - ChatGPT: `https://chatgpt.com/*` and `https://chat.openai.com/*`
+  - Claude: `https://claude.ai/*`
 
 ## Key Constants
 
-Energy calculation uses EcoLogits v0.9.x methodology constants in `energy-calculator.js`. The model is configured for GPT-5 (300B total params, 60B active params MoE). Uses H100 GPUs, batch size 64, and USA electricity mix emission factor.
+Energy calculation uses EcoLogits v0.9.x methodology constants in `energy-calculator.js`. Model parameters are provider-specific:
+- **ChatGPT (GPT-5)**: 300B total params, 60B active params (MoE architecture)
+- **Claude (3 Opus proxy)**: 2T total params, 400B active params (MoE architecture, ~14.8× more energy than ChatGPT)
+
+All calculations assume H100 GPUs, batch size 64, and USA electricity mix emission factor.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A browser extension (for now only Chrome) that estimates the environmental impac
 
 ## Features
 
-- **Real-time Energy Tracking**: Monitors your ChatGPT conversations and calculates energy consumption
+- **Real-time Energy Tracking**: Monitors your AI chat conversations (ChatGPT and Claude) and calculates energy consumption
 - **EcoLogits v0.9.x Methodology**: Energy estimates based on academic research (EcoLogits methodology)
 - **Relatable Equivalents**: Understand your impact through everyday comparisons:
   - 📺 YouTube streaming time
@@ -30,10 +30,10 @@ A browser extension (for now only Chrome) that estimates the environmental impac
 - **Privacy-Focused**: No data collection, all tracking happens locally
 
 ## How it works
-This extension tracks messages the user sends to ChatGPT, tries to catch the number of output tokens by the models based on the character size of it's response, then it calculates the energy footprint. More on the methodology: https://github.com/simonaszilinskas/ai-impact-tracker/blob/main/methodology.md
+This extension tracks messages you send to AI chat platforms, estimates the number of output tokens based on response length, then calculates the energy footprint using provider-specific model parameters. More on the methodology: https://github.com/simonaszilinskas/ai-impact-tracker/blob/main/methodology.md
 
 ## Current status
-- Works exclusively with ChatGPT for now, with plans to support more AI platforms
+- Currently supports ChatGPT and Claude, with plans to support more AI platforms
 - First version will soon be published on the Chrome Web Store
 - Open to contributions
 

--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ chrome.runtime.onInstalled.addListener((details) => {
     // Fresh install
     console.log("Fresh install - initializing storage");
     chrome.storage.local.set({ 
-      chatgptLogs: [], 
+      aiChatLogs: [], 
       extensionVersion: chrome.runtime.getManifest().version 
     });
   } else if (details.reason === 'update') {
@@ -20,7 +20,7 @@ chrome.runtime.onInstalled.addListener((details) => {
     console.log("Extension update detected - preserving data");
     
     try {
-      chrome.storage.local.get(['chatgptLogs', 'extensionVersion'], (result) => {
+      chrome.storage.local.get(['aiChatLogs', 'extensionVersion'], (result) => {
         // Check for runtime errors
         if (chrome.runtime.lastError) {
           console.error("Error accessing storage during update:", chrome.runtime.lastError);
@@ -35,16 +35,16 @@ chrome.runtime.onInstalled.addListener((details) => {
         
         // Extra log to debug upgrade path
         console.log("Existing data:", {
-          hasLogs: !!result.chatgptLogs,
-          logsIsArray: Array.isArray(result.chatgptLogs),
-          logsCount: Array.isArray(result.chatgptLogs) ? result.chatgptLogs.length : 0
+          hasLogs: !!result.aiChatLogs,
+          logsIsArray: Array.isArray(result.aiChatLogs),
+          logsCount: Array.isArray(result.aiChatLogs) ? result.aiChatLogs.length : 0
         });
         
-        // Make sure chatgptLogs exists and is valid
-        if (!result.chatgptLogs || !Array.isArray(result.chatgptLogs)) {
+        // Make sure aiChatLogs exists and is valid
+        if (!result.aiChatLogs || !Array.isArray(result.aiChatLogs)) {
           console.warn("Invalid logs format detected during update, repairing...");
           chrome.storage.local.set({ 
-            chatgptLogs: [], 
+            aiChatLogs: [], 
             extensionVersion: newVersion 
           });
         } else {

--- a/content.js
+++ b/content.js
@@ -1,12 +1,16 @@
 /**
  * AI Impact Tracker - Content Script
  * =====================================
- * This script captures conversation data from the ChatGPT web interface,
+ * This script captures conversation data from AI chat interfaces (ChatGPT, Claude),
  * extracts message content, calculates token usage, energy consumption,
  * and CO2 emissions. It persists data to Chrome storage for the popup UI.
  *
- * Note: energy-calculator.js is loaded before this file via manifest.json
- * The calculateEnergyAndEmissions() function is available in global scope.
+ * Note: providers.js and energy-calculator.js are loaded before this file via manifest.json
+ * The calculateEnergyAndEmissions() function and provider detection are available in global scope.
+ *
+ * Behavior on unsupported pages:
+ * - If no provider is detected, the extension remains dormant (no scanning, no UI, no errors)
+ * - Extension only activates on supported platforms (see providers.js for full list)
  */
 
 // In-memory storage for conversation logs
@@ -14,6 +18,24 @@ const logs = [];
 let conversationId = null;
 let isExtensionContextValid = true; // Track if extension context is still valid
 let intervalIds = []; // Track all intervals to clear them if context is invalidated
+
+// Detect the active provider for this page
+let activeProvider = null;
+
+/**
+ * Initializes the provider for the current page
+ * @returns {boolean} True if provider detected, false otherwise
+ */
+function initializeProvider() {
+  activeProvider = detectProvider();
+  if (activeProvider) {
+    console.log(`AI Impact Tracker: Detected provider - ${activeProvider.name}`);
+    return true;
+  } else {
+    console.log('AI Impact Tracker: No supported provider detected for this page, extension will remain inactive');
+    return false;
+  }
+}
 
 /**
  * Checks if the extension context is still valid
@@ -73,18 +95,23 @@ function saveToStorage(data) {
 /**
  * Saves or updates a conversation exchange
  * @param {string} userMessage - The user's message
- * @param {string} assistantResponse - ChatGPT's response
+ * @param {string} assistantResponse - Assistant's response
  */
 async function saveLog(userMessage, assistantResponse) {
+  // Guard: only proceed if we have an active provider
+  if (!activeProvider) {
+    return;
+  }
+
   // Use message prefix as unique identifier for this exchange
   const userMessageKey = userMessage.substring(0, 100);
-  
-  // Estimate token count (4 chars ≈ 1 token for English text)
-  const userTokenCount = Math.ceil(userMessage.length / 4);
-  const assistantTokenCount = Math.ceil(assistantResponse.length / 4);
-  
-  // Calculate environmental impact using EcoLogits v0.9.x methodology
-  const energyData = calculateEnergyAndEmissions(assistantTokenCount);
+
+  // Estimate token count using provider-specific logic
+  const userTokenCount = activeProvider.estimateTokens(userMessage);
+  const assistantTokenCount = activeProvider.estimateTokens(assistantResponse);
+
+  // Calculate environmental impact using EcoLogits v0.9.x methodology with provider's model params
+  const energyData = calculateEnergyAndEmissions(assistantTokenCount, activeProvider.modelParams);
   const energyUsage = energyData.totalEnergy;
   const co2Emissions = energyData.co2Emissions;
   
@@ -112,7 +139,7 @@ async function saveLog(userMessage, assistantResponse) {
         lastUpdated: Date.now()
       };
       
-      saveToStorage({ chatgptLogs: logs });
+      saveToStorage({ aiChatLogs: logs });
       shouldUpdateNotification = true;
     }
   } else {
@@ -122,6 +149,7 @@ async function saveLog(userMessage, assistantResponse) {
       lastUpdated: Date.now(),
       url: window.location.href,
       conversationId: conversationId,
+      provider: activeProvider.id, // Store provider ID for recalculation
       userMessage: userMessage,
       assistantResponse: assistantResponse,
       userTokenCount: userTokenCount,
@@ -129,9 +157,9 @@ async function saveLog(userMessage, assistantResponse) {
       energyUsage: energyUsage,
       co2Emissions: co2Emissions
     };
-    
+
     logs.push(logEntry);
-    saveToStorage({ chatgptLogs: logs });
+    saveToStorage({ aiChatLogs: logs });
     shouldUpdateNotification = true;
   }
   
@@ -145,81 +173,36 @@ async function saveLog(userMessage, assistantResponse) {
 }
 
 /**
- * Scans the DOM for ChatGPT conversation messages
- * Uses data attributes specific to ChatGPT's DOM structure
+ * Scans the DOM for conversation messages using provider-specific selectors
  * Includes error handling to prevent extension crashes
  */
 async function scanMessages() {
-  // Skip if extension context is invalidated
-  if (!isExtensionContextValid) {
+  // Skip if extension context is invalidated or no provider
+  if (!isExtensionContextValid || !activeProvider) {
     return false;
   }
-  
+
   try {
-    // Find all user and assistant messages by their data attributes
-    const userMessages = [...document.querySelectorAll('[data-message-author-role="user"]')];
-    const assistantMessages = [...document.querySelectorAll('[data-message-author-role="assistant"]')];
-    
-    // Attempt alternative selectors if the primary ones didn't find anything
-    let foundMessages = userMessages.length > 0 && assistantMessages.length > 0;
-    
-    // If we didn't find any messages with the primary selectors, try alternative ones
-    if (!foundMessages) {
-      // Try some alternative selectors that might match different versions of ChatGPT
-      const alternativeUserSelectors = [
-        '.markdown p', // Look for paragraph text in markdown areas
-        '[data-role="user"]', 
-        '.user-message',
-        '[data-testid="user-message"]',
-        '.text-message-content'
-      ];
-      
-      const alternativeAssistantSelectors = [
-        '.markdown p',
-        '[data-role="assistant"]',
-        '.assistant-message', 
-        '[data-testid="assistant-message"]',
-        '.assistant-response'
-      ];
-      
-      // Try each alternative selector
-      for (const userSelector of alternativeUserSelectors) {
-        const altUserMessages = document.querySelectorAll(userSelector);
-        if (altUserMessages.length > 0) {
-          for (const assistantSelector of alternativeAssistantSelectors) {
-            const altAssistantMessages = document.querySelectorAll(assistantSelector);
-            if (altAssistantMessages.length > 0) {
-              console.log(`Found alternative selectors: ${userSelector} (${altUserMessages.length}) and ${assistantSelector} (${altAssistantMessages.length})`);
-              
-              // Try to process these alternative messages
-              for (let i = 0; i < Math.min(altUserMessages.length, altAssistantMessages.length); i++) {
-                try {
-                  const userMessage = altUserMessages[i].textContent.trim();
-                  const assistantResponse = altAssistantMessages[i].textContent.trim();
-                  
-                  if (userMessage && assistantResponse) {
-                    // Save any non-empty exchange
-                    await saveLog(userMessage, assistantResponse);
-                    foundMessages = true;
-                  }
-                } catch (altMessageError) {
-                  console.error("Error processing alternative message pair:", altMessageError);
-                }
-              }
-              
-              // If we found messages with this selector pair, stop trying others
-              if (foundMessages) break;
-            }
+    // Try provider's selectors in order of preference
+    let userMessages = [];
+    let assistantMessages = [];
+    let foundMessages = false;
+
+    // Try each user message selector until we find matches
+    for (const userSelector of activeProvider.selectors.userMessage) {
+      userMessages = [...document.querySelectorAll(userSelector)];
+      if (userMessages.length > 0) {
+        // Try each assistant message selector
+        for (const assistantSelector of activeProvider.selectors.assistantMessage) {
+          assistantMessages = [...document.querySelectorAll(assistantSelector)];
+          if (assistantMessages.length > 0) {
+            foundMessages = true;
+            console.log(`Found messages using selectors: ${userSelector} (${userMessages.length}) and ${assistantSelector} (${assistantMessages.length})`);
+            break;
           }
-          // If we found messages with any assistant selector, stop trying other user selectors
-          if (foundMessages) break;
         }
+        if (foundMessages) break;
       }
-    }
-    
-    // Log the results of the scan for debugging
-    if (userMessages.length > 0 || assistantMessages.length > 0) {
-      console.log(`Found ${userMessages.length} user messages and ${assistantMessages.length} assistant messages`);
     }
     
     // Process message pairs in order
@@ -252,21 +235,28 @@ async function scanMessages() {
  * Uses a fetch proxy pattern to capture API responses without affecting functionality
  */
 function setupFetchInterceptor() {
+  // Skip if no provider
+  if (!activeProvider || !activeProvider.apiPatterns) {
+    return;
+  }
+
   const originalFetch = window.fetch;
-  
+
   window.fetch = async function(resource, init) {
     const url = resource instanceof Request ? resource.url : resource;
-    
+
     // Call original fetch
     const response = await originalFetch.apply(this, arguments);
-    
-    // Process conversation API responses
-    if (typeof url === 'string' && url.includes('conversation')) {
+
+    // Process conversation API responses using provider patterns
+    if (typeof url === 'string' && url.includes(activeProvider.apiPatterns.conversationMatch)) {
       try {
-        // Extract conversation ID from URL
-        const match = url.match(/\/c\/([a-zA-Z0-9-]+)/);
-        if (match && match[1]) {
-          conversationId = match[1];
+        // Extract conversation ID from URL using provider's extractor
+        if (activeProvider.apiPatterns.extractConversationId) {
+          const extractedId = activeProvider.apiPatterns.extractConversationId(url);
+          if (extractedId) {
+            conversationId = extractedId;
+          }
         }
         
         // Process server-sent events streams
@@ -336,21 +326,30 @@ function setupFetchInterceptor() {
  * Efficiently triggers scans only when relevant content changes
  */
 function setupObserver() {
+  // Skip if no provider
+  if (!activeProvider) {
+    return;
+  }
+
   // Track the time of the last update to avoid excessive updates
   let lastUpdateTime = 0;
-  
+
   const observer = new MutationObserver(async (mutations) => {
     let shouldScan = false;
-    
+
     // Check if any assistant messages were added or modified
     for (const mutation of mutations) {
       if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
         for (const node of mutation.addedNodes) {
-          if (node.nodeType === Node.ELEMENT_NODE && 
-              (node.getAttribute('data-message-author-role') === 'assistant' || 
-               node.querySelector('[data-message-author-role="assistant"]'))) {
-            shouldScan = true;
-            break;
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            // Check against provider's assistant message selectors
+            for (const selector of activeProvider.selectors.assistantMessage) {
+              if (node.matches && node.matches(selector) || node.querySelector && node.querySelector(selector)) {
+                shouldScan = true;
+                break;
+              }
+            }
+            if (shouldScan) break;
           }
         }
       } else if (mutation.type === 'characterData') {
@@ -358,7 +357,7 @@ function setupObserver() {
         // This can catch typing updates on the assistant's responses
         shouldScan = true;
       }
-      
+
       if (shouldScan) break;
     }
     
@@ -655,24 +654,34 @@ function updateUsageNotification() {
  * Initializes the extension functionality
  */
 function initialize() {
+  // First, detect the provider for this page
+  const providerDetected = initializeProvider();
+
+  // If no provider detected, exit early (extension remains dormant)
+  if (!providerDetected) {
+    console.log('AI Impact Tracker: No provider detected, extension will not activate');
+    return;
+  }
+
   // Load existing logs from storage with improved error handling and retry
   initializeWithRetry(3);
-  
+
   // Setup periodic storage validation to fix potential issues
-  setInterval(validateAndRepairStorage, 5 * 60 * 1000); // Every 5 minutes
-  
+  const validationInterval = setInterval(validateAndRepairStorage, 5 * 60 * 1000); // Every 5 minutes
+  intervalIds.push(validationInterval);
+
   // Setup when DOM is ready
   const setupUI = async () => {
     setupFetchInterceptor();
     setupObserver();
     await scanMessages(); // Initial scan
-    
+
     // Create notification if not created yet
     if (!document.getElementById('ai-impact-notification')) {
       createUsageNotification();
     }
   };
-  
+
   if (document.readyState === "complete" || document.readyState === "interactive") {
     setTimeout(setupUI, 1000);
   } else {
@@ -680,23 +689,25 @@ function initialize() {
       setTimeout(setupUI, 1000);
     });
   }
-  
+
   // Monitor URL changes to detect new conversations
   let lastUrl = window.location.href;
   const urlMonitorInterval = setInterval(() => {
     if (lastUrl !== window.location.href) {
       lastUrl = window.location.href;
-      
-      // Extract conversation ID from URL
+
+      // Extract conversation ID from URL using provider's extractor
       try {
-        const match = window.location.href.match(/\/c\/([a-zA-Z0-9-]+)/);
-        if (match && match[1]) {
-          conversationId = match[1];
+        if (activeProvider && activeProvider.apiPatterns && activeProvider.apiPatterns.extractConversationId) {
+          const extractedId = activeProvider.apiPatterns.extractConversationId(window.location.href);
+          if (extractedId) {
+            conversationId = extractedId;
+          }
         }
       } catch {
         // Ignore URL parsing errors
       }
-      
+
       // Scan after URL change
       setTimeout(async () => await scanMessages(), 1000);
     }
@@ -728,12 +739,12 @@ function reloadLogsFromStorage() {
     }
     
     try {
-      chrome.storage.local.get(['chatgptLogs'], function(result) {
+      chrome.storage.local.get(['aiChatLogs'], function(result) {
         if (chrome.runtime.lastError) {
           console.error('Error reloading logs from storage:', chrome.runtime.lastError);
           resolve();
         } else {
-          const storedLogs = result.chatgptLogs || [];
+          const storedLogs = result.aiChatLogs || [];
           // Update the in-memory logs array with the recalculated values
           logs.length = 0; // Clear existing logs
           logs.push(...storedLogs); // Add the updated logs
@@ -790,7 +801,7 @@ function validateAndRepairStorage() {
   console.log("Running storage validation check...");
   
   try {
-    chrome.storage.local.get(['chatgptLogs', 'extensionVersion'], (result) => {
+    chrome.storage.local.get(['aiChatLogs', 'extensionVersion'], (result) => {
     if (chrome.runtime.lastError) {
       console.error("Error checking storage:", chrome.runtime.lastError);
       return;
@@ -799,7 +810,7 @@ function validateAndRepairStorage() {
     let needsRepair = false;
     
     // Check if logs exists and is an array
-    if (!result.chatgptLogs || !Array.isArray(result.chatgptLogs)) {
+    if (!result.aiChatLogs || !Array.isArray(result.aiChatLogs)) {
       console.warn("Invalid logs format in storage, needs repair");
       needsRepair = true;
     }
@@ -815,14 +826,14 @@ function validateAndRepairStorage() {
       if (logs && Array.isArray(logs) && logs.length > 0) {
         console.log("Repairing storage with in-memory logs");
         chrome.storage.local.set({ 
-          chatgptLogs: logs,
+          aiChatLogs: logs,
           extensionVersion: chrome.runtime.getManifest().version
         });
       } else {
         // Otherwise initialize fresh (last resort)
         console.log("Initializing fresh logs in storage");
         chrome.storage.local.set({ 
-          chatgptLogs: [],
+          aiChatLogs: [],
           extensionVersion: chrome.runtime.getManifest().version
         });
       }
@@ -849,7 +860,7 @@ function validateAndRepairStorage() {
 function initializeWithRetry(retryCount = 3) {
   console.log(`Initializing with ${retryCount} retries remaining`);
   try {
-    chrome.storage.local.get(['chatgptLogs', 'extensionVersion'], (result) => {
+    chrome.storage.local.get(['aiChatLogs', 'extensionVersion'], (result) => {
       // Check for runtime error
       if (chrome.runtime.lastError) {
         console.error("Error loading logs:", chrome.runtime.lastError);
@@ -878,12 +889,12 @@ function initializeWithRetry(retryCount = 3) {
       console.log(`Extension version: Current=${currentVersion}, Stored=${storedVersion}`);
       
       // Load logs with validation
-      if (result && result.chatgptLogs && Array.isArray(result.chatgptLogs)) {
+      if (result && result.aiChatLogs && Array.isArray(result.aiChatLogs)) {
         try {
           // Clear any potential stale data
           logs.length = 0;
-          logs.push(...result.chatgptLogs);
-          console.log(`Loaded ${result.chatgptLogs.length} conversation logs`);
+          logs.push(...result.aiChatLogs);
+          console.log(`Loaded ${result.aiChatLogs.length} conversation logs`);
         } catch (arrayError) {
           console.error("Error adding logs to array:", arrayError);
           logs.length = 0;

--- a/energy-calculator.js
+++ b/energy-calculator.js
@@ -57,34 +57,26 @@ const ECOLOGITS_CONSTANTS = {
 };
 
 /**
- * GPT-5 model parameters
- * Based on the latest model configuration
- */
-const GPT5_PARAMS = {
-  TOTAL_PARAMS: 300e9,        // 300 billion total parameters
-  ACTIVE_PARAMS: 60e9,        // 60 billion active parameters (average of 30-90B range)
-  ACTIVE_PARAMS_BILLIONS: 60, // Active params in billions (for formula)
-  ACTIVATION_RATIO: 0.2,      // 20% activation ratio (average: 60B/300B)
-  ACTIVE_PARAMS_MIN: 30e9,    // Minimum active parameters (30 billion)
-  ACTIVE_PARAMS_MAX: 90e9     // Maximum active parameters (90 billion)
-};
-
-/**
  * Calculates energy usage and CO2 emissions for LLM inference
  * using the EcoLogits v0.9.x methodology.
  *
  * @param {number} outputTokens - Number of tokens in the assistant's response
+ * @param {Object} modelParams - Model-specific parameters (required)
+ * @param {number} modelParams.totalParams - Total model parameters
+ * @param {number} modelParams.activeParams - Active parameters
+ * @param {number} modelParams.activeParamsBillions - Active params in billions (for formula)
+ * @param {number} modelParams.activationRatio - Activation ratio
  * @returns {Object} Energy and emissions data
  * @returns {number} returns.totalEnergy - Total energy consumption (Wh)
  * @returns {number} returns.co2Emissions - CO2 emissions (grams)
  * @returns {number} returns.numGPUs - Number of GPUs required
  * @returns {Object} returns.modelDetails - Additional model details
- *
- * @example
- * const result = calculateEnergyAndEmissions(100);
- * console.log(result.totalEnergy); // ~0.24 Wh
  */
-function calculateEnergyAndEmissions(outputTokens) {
+function calculateEnergyAndEmissions(outputTokens, modelParams) {
+  if (!modelParams) {
+    throw new Error('modelParams is required. Pass provider-specific model parameters.');
+  }
+
   const {
     GPU_ENERGY_ALPHA,
     GPU_ENERGY_BETA,
@@ -101,7 +93,18 @@ function calculateEnergyAndEmissions(outputTokens) {
     EMISSION_FACTOR
   } = ECOLOGITS_CONSTANTS;
 
-  const { TOTAL_PARAMS, ACTIVE_PARAMS, ACTIVE_PARAMS_BILLIONS, ACTIVATION_RATIO } = GPT5_PARAMS;
+  const { totalParams, activeParams, activeParamsBillions, activationRatio } = modelParams;
+
+  // Validate required parameters
+  if (!totalParams || !activeParams || !activeParamsBillions || activationRatio === undefined) {
+    throw new Error('modelParams must include: totalParams, activeParams, activeParamsBillions, and activationRatio');
+  }
+
+  // Convert to standardized naming for compatibility
+  const TOTAL_PARAMS = totalParams;
+  const ACTIVE_PARAMS = activeParams;
+  const ACTIVE_PARAMS_BILLIONS = activeParamsBillions;
+  const ACTIVATION_RATIO = activationRatio;
 
   // Step 1: GPU energy per token (kWh)
   // Exponential model: f_E(P_active, B) = α·exp(β·B)·P_active + γ, then /1000 for kWh
@@ -153,23 +156,33 @@ function calculateEnergyAndEmissions(outputTokens) {
  * Helper function to get energy per token
  * Useful for displaying rate information in UI
  *
+ * @param {Object} modelParams - Model-specific parameters (required)
+ * @param {number} modelParams.activeParamsBillions - Active params in billions
  * @returns {number} Energy per token in kWh/token (per GPU)
  */
-function getEnergyPerToken() {
+function getEnergyPerToken(modelParams) {
+  if (!modelParams || !modelParams.activeParamsBillions) {
+    throw new Error('modelParams with activeParamsBillions is required');
+  }
   const { GPU_ENERGY_ALPHA, GPU_ENERGY_BETA, GPU_ENERGY_GAMMA, BATCH_SIZE } = ECOLOGITS_CONSTANTS;
-  const { ACTIVE_PARAMS_BILLIONS } = GPT5_PARAMS;
-  return (GPU_ENERGY_ALPHA * Math.exp(GPU_ENERGY_BETA * BATCH_SIZE) * ACTIVE_PARAMS_BILLIONS + GPU_ENERGY_GAMMA) / 1000;
+  const { activeParamsBillions } = modelParams;
+  return (GPU_ENERGY_ALPHA * Math.exp(GPU_ENERGY_BETA * BATCH_SIZE) * activeParamsBillions + GPU_ENERGY_GAMMA) / 1000;
 }
 
 /**
- * Helper function to get the number of GPUs required for GPT-5
+ * Helper function to get the number of GPUs required for a model
  *
+ * @param {Object} modelParams - Model-specific parameters (required)
+ * @param {number} modelParams.totalParams - Total model parameters
  * @returns {number} Number of GPUs required
  */
-function getNumGPUs() {
+function getNumGPUs(modelParams) {
+  if (!modelParams || !modelParams.totalParams) {
+    throw new Error('modelParams with totalParams is required');
+  }
   const { GPU_MEMORY, GPU_BITS } = ECOLOGITS_CONSTANTS;
-  const { TOTAL_PARAMS } = GPT5_PARAMS;
-  const memoryRequired = 1.2 * TOTAL_PARAMS * GPU_BITS / 8;
+  const { totalParams } = modelParams;
+  const memoryRequired = 1.2 * totalParams * GPU_BITS / 8;
   const numGPUsRaw = Math.ceil(memoryRequired / (GPU_MEMORY * 1e9));
   return Math.pow(2, Math.ceil(Math.log2(numGPUsRaw))); // power-of-2 rounding
 }
@@ -179,7 +192,6 @@ function getNumGPUs() {
 if (typeof window !== 'undefined') {
   // Browser context - make available globally
   window.ECOLOGITS_CONSTANTS = ECOLOGITS_CONSTANTS;
-  window.GPT5_PARAMS = GPT5_PARAMS;
   window.calculateEnergyAndEmissions = calculateEnergyAndEmissions;
   window.getEnergyPerToken = getEnergyPerToken;
   window.getNumGPUs = getNumGPUs;
@@ -189,7 +201,6 @@ if (typeof window !== 'undefined') {
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     ECOLOGITS_CONSTANTS,
-    GPT5_PARAMS,
     calculateEnergyAndEmissions,
     getEnergyPerToken,
     getNumGPUs

--- a/global-scale.js
+++ b/global-scale.js
@@ -3,19 +3,20 @@
  * ===================================================
  *
  * This module provides functionality to contextualize individual AI usage
- * at a global scale by comparing what would happen if all ChatGPT users
+ * at a global scale by comparing what would happen if all AI chat users
  * consumed the same amount of energy.
  *
- * Formula: User's daily average × 900 million ChatGPT WAU × 365 days
+ * Formula: User's daily average × 900 million AI chat WAU × 365 days
  * Result: Compared against annual electricity consumption of cities, countries, and continents
  *
  * @module global-scale
  */
 
 /**
- * Estimated ChatGPT weekly active users (WAU) for scaling calculations (2025 estimate)
+ * Estimated AI chat weekly active users (WAU) for scaling calculations
+ * Using ChatGPT WAU as proxy (2025 estimate: 900M)
  */
-const CHATGPT_WAU = 900e6; // 900 million weekly active users
+const AI_CHAT_WAU = 900e6; // 900 million weekly active users
 
 /**
  * Days in a year for annual calculations
@@ -84,15 +85,15 @@ const ELECTRICITY_CONSUMPTION_REFERENCE = [
 
 /**
  * Calculates what the total electricity consumption would be if all
- * ChatGPT users consumed the same amount as this user
+ * AI chat users consumed the same amount as this user
  *
  * @param {number} dailyAverageWh - User's daily average energy consumption in Wh
- * @returns {number} Annual consumption across all ChatGPT users in TWh
+ * @returns {number} Annual consumption across all AI chat users in TWh
  */
 function calculateGlobalAnnualConsumption(dailyAverageWh) {
-  // Convert Wh to TWh and scale to all ChatGPT users over a year
+  // Convert Wh to TWh and scale to all AI chat users over a year
   // Formula: (Wh/day) × (900M users) × (365 days/year) × (1 TWh / 1e12 Wh)
-  const globalAnnualTWh = dailyAverageWh * CHATGPT_WAU * DAYS_PER_YEAR / 1e12;
+  const globalAnnualTWh = dailyAverageWh * AI_CHAT_WAU * DAYS_PER_YEAR / 1e12;
   return globalAnnualTWh;
 }
 
@@ -217,7 +218,7 @@ function getGlobalScaleComparison(dailyAverageWh) {
   // Construct the message
   const relationshipText = comparison.relationship ? ` ${comparison.relationship}` : '';
   const message = `You consume ${dailyAverageWh.toFixed(2)} Wh per day on average. ` +
-    `If all 900M ChatGPT users consumed as much per day, in a year it would represent ` +
+    `If all 900M AI chat users consumed as much per day, in a year it would represent ` +
     `${formattedGlobalConsumption} — ${comparison.formattedRatio}${relationshipText} ` +
     `${closestEntity.name}'s annual electricity consumption ` +
     `(${closestEntity.consumption.toFixed(1)} TWh).`;
@@ -244,7 +245,7 @@ function getGlobalScaleComparison(dailyAverageWh) {
 
 // Make functions available globally for browser context
 if (typeof window !== 'undefined') {
-  window.CHATGPT_WAU = CHATGPT_WAU;
+  window.AI_CHAT_WAU = AI_CHAT_WAU;
   window.DAYS_PER_YEAR = DAYS_PER_YEAR;
   window.ELECTRICITY_CONSUMPTION_REFERENCE = ELECTRICITY_CONSUMPTION_REFERENCE;
   window.calculateGlobalAnnualConsumption = calculateGlobalAnnualConsumption;
@@ -256,7 +257,7 @@ if (typeof window !== 'undefined') {
 // CommonJS exports for Node.js testing
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
-    CHATGPT_WAU,
+    AI_CHAT_WAU,
     DAYS_PER_YEAR,
     ELECTRICITY_CONSUMPTION_REFERENCE,
     calculateGlobalAnnualConsumption,

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,11 @@
     "version": "2.4",
     "description": "Track the environmental impact of your AI usage with relatable equivalents",
     "permissions": ["storage"],
-    "host_permissions": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
+    "host_permissions": [
+      "https://chatgpt.com/*",
+      "https://chat.openai.com/*",
+      "https://claude.ai/*"
+    ],
     "background": {
       "service_worker": "background.js"
     },
@@ -16,8 +20,12 @@
     },
     "content_scripts": [
       {
-        "matches": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
-        "js": ["energy-calculator.js", "content.js"],
+        "matches": [
+          "https://chatgpt.com/*",
+          "https://chat.openai.com/*",
+          "https://claude.ai/*"
+        ],
+        "js": ["providers.js", "energy-calculator.js", "content.js"],
         "run_at": "document_start"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.0",
   "description": "Track the environmental impact of your AI usage",
   "scripts": {
-    "test": "node test-refactoring.js && node verify-fix.js && node test-global-scale.js"
+    "test": "node test-refactoring.js && node verify-fix.js && node test-global-scale.js && node test-providers.js"
   },
   "keywords": ["ai", "energy", "environmental", "carbon", "chatgpt"],
   "author": "Simon Zilinskas",

--- a/popup.html
+++ b/popup.html
@@ -358,6 +358,7 @@
     }
 
   </style>
+  <script src="providers.js"></script>
   <script src="energy-calculator.js"></script>
   <script src="global-scale.js"></script>
   <script src="popup.js"></script>
@@ -505,10 +506,10 @@
       <div class="global-scale-section" id="lifetime-global-scale">
         <div class="global-scale-header">
           <span class="emoji">🌍</span>
-          <span>ChatGPT-scale perspective</span>
+          <span>Global-scale perspective</span>
         </div>
         <div class="global-scale-message" id="lifetime-global-scale-message">
-          Start using ChatGPT to see your impact at scale!
+          Start chatting to see your impact at scale!
         </div>
       </div>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -4,8 +4,8 @@
  * This script handles the popup UI functionality including loading,
  * displaying usage logs and environmental metrics.
  *
- * Note: energy-calculator.js is loaded before this file via popup.html
- * The calculateEnergyAndEmissions() function is available from window.calculateEnergyAndEmissions
+ * Note: providers.js and energy-calculator.js are loaded before this file via popup.html
+ * The calculateEnergyAndEmissions() function and provider utilities are available from window
  */
 
 /**
@@ -158,7 +158,7 @@ function loadLogs() {
       return; // We already initialized with empty stats
     }
     
-    storage.get(['chatgptLogs', 'extensionVersion'], function(result) {
+    storage.get(['aiChatLogs', 'extensionVersion'], function(result) {
       // Check for chrome.runtime.lastError safely
       const lastError = chrome.runtime && chrome.runtime.lastError;
       if (lastError) {
@@ -171,7 +171,7 @@ function loadLogs() {
         return;
       }
       
-      const logs = result.chatgptLogs || [];
+      const logs = result.aiChatLogs || [];
       const version = result.extensionVersion || 'unknown';
       console.log(`Loaded ${logs.length} logs from storage (extension version: ${version})`);
       
@@ -184,7 +184,7 @@ function loadLogs() {
         
         // Attempt to repair storage
         chrome.storage.local.set({ 
-          chatgptLogs: [],
+          aiChatLogs: [],
           extensionVersion: chrome.runtime.getManifest().version 
         });
         return;
@@ -226,14 +226,14 @@ function tryLoadLogsAgain() {
       return; // We already initialized with empty stats
     }
     
-    storage.get('chatgptLogs', function(result) {
+    storage.get('aiChatLogs', function(result) {
       // Safely handle result
       if (!result) {
         console.warn('No result from storage in retry');
         return;
       }
       
-      const logs = Array.isArray(result.chatgptLogs) ? result.chatgptLogs : [];
+      const logs = Array.isArray(result.aiChatLogs) ? result.aiChatLogs : [];
       console.log(`Retry loaded ${logs.length} logs from storage`);
       
       updateTodayStats(logs);
@@ -453,7 +453,7 @@ function updateGlobalScaleComparison(logs, totalEnergyUsage) {
 
   // Calculate daily average energy usage
   if (logs.length === 0 || totalEnergyUsage <= 0) {
-    messageElement.innerHTML = 'Start using ChatGPT to see your impact at scale!';
+    messageElement.innerHTML = 'Start chatting to see your impact at scale!';
     return;
   }
 
@@ -599,18 +599,31 @@ function recalculateAllLogs() {
   const storage = getChromeStorage();
   if (!storage) return;
 
-  storage.get(['chatgptLogs'], function(result) {
-    const logs = result.chatgptLogs || [];
+  storage.get(['aiChatLogs'], function(result) {
+    const logs = result.aiChatLogs || [];
 
     logs.forEach(log => {
+      // Skip logs without provider (legacy logs before provider abstraction)
+      if (!log.provider) {
+        console.warn('Skipping log without provider information');
+        return;
+      }
+
       if (log.assistantTokenCount > 0) {
-        const energyData = calculateEnergyAndEmissions(log.assistantTokenCount);
+        // Get provider model params for recalculation
+        const provider = getProviderById(log.provider);
+        if (!provider) {
+          console.warn(`Unknown provider: ${log.provider}, skipping log`);
+          return;
+        }
+
+        const energyData = calculateEnergyAndEmissions(log.assistantTokenCount, provider.modelParams);
         log.energyUsage = energyData.totalEnergy;
         log.co2Emissions = energyData.co2Emissions;
       }
     });
 
-    storage.set({ chatgptLogs: logs }, function() {
+    storage.set({ aiChatLogs: logs }, function() {
       updateTodayStats(logs);
       updateLifetimeStats(logs);
       console.log(`Recalculated ${logs.length} logs with EcoLogits v0.9.x methodology`);

--- a/providers.js
+++ b/providers.js
@@ -1,0 +1,249 @@
+/**
+ * AI Impact Tracker - Provider Abstraction Layer
+ * ===============================================
+ *
+ * This module defines the provider interface for different AI platforms.
+ * Each provider specifies DOM selectors, token estimation logic, and
+ * model-specific parameters for energy calculations.
+ *
+ * Adding a new provider:
+ * 1. Create a provider object with the required fields
+ * 2. Add it to the PROVIDERS array
+ * 3. Update manifest.json with host permissions
+ *
+ * @module providers
+ */
+
+/**
+ * Provider interface definition:
+ *
+ * @typedef {Object} Provider
+ * @property {string} id - Unique identifier (e.g., 'chatgpt', 'claude')
+ * @property {string} name - Display name (e.g., 'ChatGPT', 'Claude')
+ * @property {string[]} urlPatterns - URL patterns to match (e.g., ['chatgpt.com', 'chat.openai.com'])
+ * @property {Object} selectors - DOM selectors for finding messages
+ * @property {string[]} selectors.userMessage - Selectors for user messages (tried in order)
+ * @property {string[]} selectors.assistantMessage - Selectors for assistant messages (tried in order)
+ * @property {string[]} [selectors.conversationContainer] - Optional selectors for conversation container
+ * @property {Function} estimateTokens - Function to estimate token count from text
+ * @property {Object} modelParams - Model-specific parameters for energy calculation
+ * @property {number} modelParams.totalParams - Total model parameters (in billions)
+ * @property {number} modelParams.activeParams - Active parameters (in billions)
+ * @property {number} modelParams.activeParamsBillions - Active params for formula
+ * @property {number} modelParams.activationRatio - Activation ratio (activeParams/totalParams)
+ * @property {number} [modelParams.activeParamsMin] - Min active params (for MoE models)
+ * @property {number} [modelParams.activeParamsMax] - Max active params (for MoE models)
+ * @property {Object} [apiPatterns] - Optional API endpoint patterns for intercepting requests
+ * @property {string} [apiPatterns.conversationMatch] - Regex pattern or string to match conversation API
+ * @property {Function} [apiPatterns.extractConversationId] - Function to extract conversation ID from URL
+ */
+
+/**
+ * ChatGPT Provider Configuration
+ */
+const CHATGPT_PROVIDER = {
+  id: 'chatgpt',
+  name: 'ChatGPT',
+  urlPatterns: ['chatgpt.com', 'chat.openai.com'],
+
+  selectors: {
+    userMessage: [
+      '[data-message-author-role="user"]',
+      '[data-role="user"]',
+      '.user-message',
+      '[data-testid="user-message"]'
+    ],
+    assistantMessage: [
+      '[data-message-author-role="assistant"]',
+      '[data-role="assistant"]',
+      '.assistant-message',
+      '[data-testid="assistant-message"]'
+    ],
+    conversationContainer: [
+      'main',
+      '[role="main"]',
+      '.conversation-content'
+    ]
+  },
+
+  /**
+   * Estimates token count for ChatGPT
+   * Uses 4 characters ≈ 1 token heuristic for English text
+   *
+   * @param {string} text - Input text
+   * @returns {number} Estimated token count
+   */
+  estimateTokens: (text) => {
+    return Math.ceil(text.length / 4);
+  },
+
+  /**
+   * GPT-5 model parameters
+   * Based on 300B total, 60B active (MoE architecture)
+   */
+  modelParams: {
+    totalParams: 300e9,        // 300 billion total parameters
+    activeParams: 60e9,        // 60 billion active parameters (average)
+    activeParamsBillions: 60,  // Active params in billions (for formula)
+    activationRatio: 0.2,      // 20% activation ratio (60B/300B)
+    activeParamsMin: 30e9,     // Min active parameters (30 billion)
+    activeParamsMax: 90e9      // Max active parameters (90 billion)
+  },
+
+  apiPatterns: {
+    conversationMatch: 'conversation',
+
+    /**
+     * Extracts conversation ID from ChatGPT URL
+     * Format: /c/{conversation_id}
+     *
+     * @param {string} url - Full URL
+     * @returns {string|null} Conversation ID or null
+     */
+    extractConversationId: (url) => {
+      const match = url.match(/\/c\/([a-zA-Z0-9-]+)/);
+      return match ? match[1] : null;
+    }
+  }
+};
+
+/**
+ * Claude Provider Configuration
+ */
+const CLAUDE_PROVIDER = {
+  id: 'claude',
+  name: 'Claude',
+  urlPatterns: ['claude.ai'],
+
+  selectors: {
+    userMessage: [
+      '[data-testid="user-message"]',
+      '.font-user-message',
+      '[data-is-author-role="user"]'
+    ],
+    assistantMessage: [
+      '.standard-markdown',  // Full message container
+      '[data-is-author-role="assistant"]'
+      // .font-claude-response-body not used - matches individual paragraphs, not full message
+    ],
+    conversationContainer: [
+      'main',
+      '[role="main"]',
+      '.conversation'
+    ]
+  },
+
+  /**
+   * Estimates token count for Claude
+   * Uses 4 characters ≈ 1 token heuristic (same as GPT)
+   *
+   * @param {string} text - Input text
+   * @returns {number} Estimated token count
+   */
+  estimateTokens: (text) => {
+    return Math.ceil(text.length / 4);
+  },
+
+  /**
+   * Claude model parameters
+   *
+   * Based on EcoLogits v0.9.x estimates for Claude 3 Opus:
+   * - Total: ~2T params, MoE architecture
+   * - Active: 200B-600B range (using 400B midpoint)
+   * - Used as proxy for all Claude models (3.5 Sonnet, etc.)
+   *
+   * Note: EcoLogits estimates for Claude have low precision due to lack of
+   * public architecture data from Anthropic. Source synced 2025-03 from
+   * https://ecologits.ai/latest/methodology/proprietary_models/
+   */
+  modelParams: {
+    totalParams: 2000e9,       // 2 trillion (EcoLogits estimate for Claude 3 Opus)
+    activeParams: 400e9,       // 400B active (midpoint of 200B-600B range)
+    activeParamsBillions: 400, // Active params in billions (for formula)
+    activationRatio: 0.2       // 20% activation (400B/2000B MoE)
+  },
+
+  apiPatterns: {
+    conversationMatch: 'chat_conversations',
+
+    /**
+     * Extracts conversation ID from Claude URL
+     * Format: /chat/{conversation_id}
+     *
+     * @param {string} url - Full URL
+     * @returns {string|null} Conversation ID or null
+     */
+    extractConversationId: (url) => {
+      const match = url.match(/\/chat\/([a-zA-Z0-9-]+)/);
+      return match ? match[1] : null;
+    }
+  }
+};
+
+/**
+ * All registered providers
+ */
+const PROVIDERS = [
+  CHATGPT_PROVIDER,
+  CLAUDE_PROVIDER
+];
+
+/**
+ * Detects the active provider based on current URL
+ *
+ * @param {string} [url=window.location.href] - URL to check
+ * @returns {Provider|null} Matching provider or null
+ */
+function detectProvider(url = window.location.href) {
+  for (const provider of PROVIDERS) {
+    for (const pattern of provider.urlPatterns) {
+      if (url.includes(pattern)) {
+        return provider;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Gets provider by ID
+ *
+ * @param {string} id - Provider ID
+ * @returns {Provider|null} Matching provider or null
+ */
+function getProviderById(id) {
+  return PROVIDERS.find(p => p.id === id) || null;
+}
+
+/**
+ * Gets all registered providers
+ *
+ * @returns {Provider[]} Array of all providers
+ */
+function getAllProviders() {
+  return [...PROVIDERS];
+}
+
+// Make functions and providers available globally for content scripts
+// and as CommonJS exports for Node.js testing
+if (typeof window !== 'undefined') {
+  // Browser context - make available globally
+  window.PROVIDERS = PROVIDERS;
+  window.CHATGPT_PROVIDER = CHATGPT_PROVIDER;
+  window.CLAUDE_PROVIDER = CLAUDE_PROVIDER;
+  window.detectProvider = detectProvider;
+  window.getProviderById = getProviderById;
+  window.getAllProviders = getAllProviders;
+}
+
+// CommonJS exports for Node.js testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    PROVIDERS,
+    CHATGPT_PROVIDER,
+    CLAUDE_PROVIDER,
+    detectProvider,
+    getProviderById,
+    getAllProviders
+  };
+}

--- a/test-global-scale.js
+++ b/test-global-scale.js
@@ -4,7 +4,7 @@
  */
 
 const {
-  CHATGPT_WAU,
+  AI_CHAT_WAU,
   DAYS_PER_YEAR,
   ELECTRICITY_CONSUMPTION_REFERENCE,
   calculateGlobalAnnualConsumption,
@@ -21,7 +21,7 @@ console.log();
 // Test 1: Constants
 console.log('Test 1: Constants Check');
 console.log('-'.repeat(80));
-console.log(`ChatGPT WAU: ${CHATGPT_WAU.toLocaleString()}`);
+console.log(`AI Chat WAU: ${AI_CHAT_WAU.toLocaleString()}`);
 console.log(`Days Per Year: ${DAYS_PER_YEAR}`);
 console.log(`Reference Entities: ${ELECTRICITY_CONSUMPTION_REFERENCE.length} entities loaded`);
 console.log(`Smallest entity: ${ELECTRICITY_CONSUMPTION_REFERENCE[0].name} (${ELECTRICITY_CONSUMPTION_REFERENCE[0].consumption} TWh)`);

--- a/test-providers.js
+++ b/test-providers.js
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * Test script for provider abstraction layer
+ * Verifies that multiple providers work correctly with the energy calculator
+ */
+
+console.log('='.repeat(70));
+console.log('VERIFICATION: Provider Abstraction Layer');
+console.log('='.repeat(70));
+console.log();
+
+// Import the provider module
+import {
+  PROVIDERS,
+  CHATGPT_PROVIDER,
+  CLAUDE_PROVIDER,
+  detectProvider,
+  getProviderById,
+  getAllProviders
+} from './providers.js';
+
+// Import energy calculator
+import {
+  calculateEnergyAndEmissions,
+  getEnergyPerToken,
+  getNumGPUs
+} from './energy-calculator.js';
+
+console.log('Successfully imported providers.js and energy-calculator.js');
+console.log();
+
+// Provider-specific test configuration
+// When adding a new provider, add its test data here
+const PROVIDER_TEST_CONFIG = {
+  chatgpt: {
+    testUrls: [
+      'https://chatgpt.com/c/abc123',
+      'https://chat.openai.com/c/xyz789'
+    ],
+    conversationIdTest: {
+      url: 'https://chatgpt.com/c/abc123xyz',
+      expectedId: 'abc123xyz'
+    },
+    expectedModelParams: {
+      totalParams: 300e9,
+      activeParams: 60e9
+    },
+    expectedGPUs: 16,
+    expected100tokens: { min: 0.23, max: 0.26 }
+  },
+  claude: {
+    testUrls: [
+      'https://claude.ai/chat/def456'
+    ],
+    conversationIdTest: {
+      url: 'https://claude.ai/chat/def456ghi',
+      expectedId: 'def456ghi'
+    },
+    expectedModelParams: {
+      totalParams: 2000e9,
+      activeParams: 400e9
+    },
+    expectedGPUs: 64,
+    expected100tokens: { min: 3.5, max: 3.7 }
+  }
+};
+
+// Test 1: Provider Registration
+console.log('Test 1: Provider Registration');
+console.log('-'.repeat(70));
+const allProviders = getAllProviders();
+console.log(`  Total providers registered: ${allProviders.length}`);
+console.log(`  Providers: ${allProviders.map(p => p.name).join(', ')}`);
+
+// Verify all expected providers are registered
+const expectedProviderIds = Object.keys(PROVIDER_TEST_CONFIG);
+const registeredIds = allProviders.map(p => p.id);
+const allExpectedPresent = expectedProviderIds.every(id => registeredIds.includes(id));
+
+if (allProviders.length === expectedProviderIds.length && allExpectedPresent) {
+  console.log('  PASS - All expected providers registered correctly');
+} else {
+  console.error('  FAIL - Provider registration mismatch');
+  console.error(`    Expected: ${expectedProviderIds.join(', ')}`);
+  console.error(`    Registered: ${registeredIds.join(', ')}`);
+  process.exit(1);
+}
+console.log();
+
+// Test 2: Provider Detection
+console.log('Test 2: Provider Detection');
+console.log('-'.repeat(70));
+
+// Generate test URLs from provider config
+const testUrls = [];
+Object.entries(PROVIDER_TEST_CONFIG).forEach(([providerId, config]) => {
+  config.testUrls.forEach(url => {
+    testUrls.push({ url, expected: providerId });
+  });
+});
+
+// Add negative test cases (URLs that should not match any provider)
+testUrls.push(
+  { url: 'https://google.com', expected: null },
+  { url: 'https://example.com', expected: null }
+);
+
+let allDetectionPassed = true;
+testUrls.forEach(({ url, expected }) => {
+  const provider = detectProvider(url);
+  const providerId = provider ? provider.id : null;
+  const passed = providerId === expected;
+  const status = passed ? 'PASS' : 'FAIL';
+  console.log(`  ${status}: ${url}`);
+  console.log(`        Detected: ${providerId || 'none'}, Expected: ${expected || 'none'}`);
+  if (!passed) allDetectionPassed = false;
+});
+
+if (allDetectionPassed) {
+  console.log('  PASS - Provider detection working correctly');
+} else {
+  console.error('  FAIL - Provider detection errors');
+  process.exit(1);
+}
+console.log();
+
+// Test 3: Provider Lookup by ID
+console.log('Test 3: Provider Lookup by ID');
+console.log('-'.repeat(70));
+
+let failureCount = 0;
+
+// Test lookup for all registered providers
+allProviders.forEach(provider => {
+  const lookedUpProvider = getProviderById(provider.id);
+  const passed = lookedUpProvider && lookedUpProvider.id === provider.id && lookedUpProvider.name === provider.name;
+  const status = passed ? 'PASS' : 'FAIL';
+  console.log(`  ${status}: getProviderById('${provider.id}') → ${lookedUpProvider ? lookedUpProvider.name : 'null'}`);
+  if (!passed) failureCount++;
+});
+
+// Test unknown ID returns null
+const unknownProvider = getProviderById('unknown');
+if (unknownProvider === null) {
+  console.log(`  PASS: getProviderById('unknown') → null`);
+} else {
+  console.log(`  FAIL: getProviderById('unknown') should return null`);
+  failureCount++;
+}
+
+if (failureCount === 0) {
+  console.log('  PASS - Provider lookup working correctly');
+} else {
+  console.error('  FAIL - Provider lookup errors');
+  process.exit(1);
+}
+console.log();
+
+// Test 4: Provider Model Parameters
+console.log('Test 4: Provider Model Parameters');
+console.log('-'.repeat(70));
+
+failureCount = 0;
+
+allProviders.forEach(provider => {
+  const config = PROVIDER_TEST_CONFIG[provider.id];
+  console.log(`  ${provider.name} Model Parameters:`);
+  console.log(`    Total params: ${provider.modelParams.totalParams / 1e9}B`);
+  console.log(`    Active params: ${provider.modelParams.activeParams / 1e9}B`);
+  console.log(`    Activation ratio: ${provider.modelParams.activationRatio * 100}%`);
+
+  // Validate against expected values
+  if (config && config.expectedModelParams) {
+    const totalMatch = provider.modelParams.totalParams === config.expectedModelParams.totalParams;
+    const activeMatch = provider.modelParams.activeParams === config.expectedModelParams.activeParams;
+    if (!totalMatch || !activeMatch) {
+      console.error(`    FAIL - Parameter mismatch for ${provider.name}`);
+      failureCount++;
+    }
+  }
+});
+
+if (failureCount === 0) {
+  console.log('  PASS - Model parameters defined correctly');
+} else {
+  console.error('  FAIL - Model parameter mismatch');
+  process.exit(1);
+}
+console.log();
+
+// Test 5: Token Estimation
+console.log('Test 5: Token Estimation Functions');
+console.log('-'.repeat(70));
+
+const testText = 'This is a test message with exactly twenty-five tokens in it for testing purposes only.';
+const expectedTokens = Math.ceil(testText.length / 4);
+
+console.log(`  Test text: "${testText}"`);
+console.log(`  Text length: ${testText.length} chars`);
+console.log(`  Expected: ~${expectedTokens} tokens (chars/4)`);
+console.log();
+
+failureCount = 0;
+
+allProviders.forEach(provider => {
+  const tokens = provider.estimateTokens(testText);
+  const passed = tokens === expectedTokens;
+  const status = passed ? 'PASS' : 'FAIL';
+  console.log(`  ${status}: ${provider.name} estimate: ${tokens} tokens`);
+  if (!passed) failureCount++;
+});
+
+if (failureCount === 0) {
+  console.log('  PASS - Token estimation working correctly');
+} else {
+  console.error('  FAIL - Token estimation mismatch');
+  process.exit(1);
+}
+console.log();
+
+// Test 6: Energy Calculations with Different Providers
+console.log('Test 6: Energy Calculations with Provider Model Params');
+console.log('-'.repeat(70));
+
+const tokens = 100;
+failureCount = 0;
+const energyResults = {};
+
+allProviders.forEach(provider => {
+  const config = PROVIDER_TEST_CONFIG[provider.id];
+  const energy = calculateEnergyAndEmissions(tokens, provider.modelParams);
+  energyResults[provider.id] = energy;
+
+  console.log(`  ${provider.name} - 100 tokens:`);
+  console.log(`    Energy: ${energy.totalEnergy.toFixed(4)} Wh`);
+  console.log(`    CO2: ${energy.co2Emissions.toFixed(4)} g`);
+  console.log(`    GPUs required: ${energy.numGPUs}`);
+
+  // Validate against expected values from config
+  if (config) {
+    const energyInRange = energy.totalEnergy >= config.expected100tokens.min &&
+                          energy.totalEnergy <= config.expected100tokens.max;
+    const gpusMatch = energy.numGPUs === config.expectedGPUs;
+
+    if (!energyInRange || !gpusMatch) {
+      console.error(`    FAIL - Values out of expected range`);
+      failureCount++;
+    }
+  }
+
+  // Basic sanity check
+  if (energy.totalEnergy <= 0 || energy.totalEnergy > 100 || energy.numGPUs <= 0) {
+    console.error(`    FAIL - Unreasonable values`);
+    failureCount++;
+  }
+});
+
+if (failureCount === 0) {
+  console.log('  PASS - Energy calculations produce reasonable values');
+} else {
+  console.error('  FAIL - Energy calculations out of expected range');
+  process.exit(1);
+}
+console.log();
+
+// Test 7: DOM Selectors
+console.log('Test 7: DOM Selectors Configuration');
+console.log('-'.repeat(70));
+
+failureCount = 0;
+
+allProviders.forEach(provider => {
+  console.log(`  ${provider.name} Selectors:`);
+  console.log(`    User messages: ${provider.selectors.userMessage.length} selectors`);
+  console.log(`    Assistant messages: ${provider.selectors.assistantMessage.length} selectors`);
+  console.log(`    Primary user selector: ${provider.selectors.userMessage[0]}`);
+
+  if (provider.selectors.userMessage.length === 0 ||
+      provider.selectors.assistantMessage.length === 0) {
+    console.error(`    FAIL - Missing selectors for ${provider.name}`);
+    failureCount++;
+  }
+});
+
+if (failureCount === 0) {
+  console.log('  PASS - All providers have DOM selectors defined');
+} else {
+  console.error('  FAIL - Missing DOM selectors for some providers');
+  process.exit(1);
+}
+console.log();
+
+// Test 8: API Patterns
+console.log('Test 8: API Patterns Configuration');
+console.log('-'.repeat(70));
+
+failureCount = 0;
+
+allProviders.forEach(provider => {
+  const config = PROVIDER_TEST_CONFIG[provider.id];
+
+  if (provider.apiPatterns && provider.apiPatterns.extractConversationId && config && config.conversationIdTest) {
+    const { url, expectedId } = config.conversationIdTest;
+    const extractedId = provider.apiPatterns.extractConversationId(url);
+
+    console.log(`  ${provider.name} conversation ID extraction:`);
+    console.log(`    URL: ${url}`);
+    console.log(`    Extracted: ${extractedId}`);
+
+    if (extractedId === expectedId) {
+      console.log('    PASS - Correct');
+    } else {
+      console.error(`    FAIL - Expected ${expectedId}, got ${extractedId}`);
+      failureCount++;
+    }
+  }
+});
+
+if (failureCount === 0) {
+  console.log('  PASS - API patterns working correctly');
+} else {
+  console.error('  FAIL - API pattern errors');
+  process.exit(1);
+}
+console.log();
+
+// Test 9: Helper Functions with Different Providers
+console.log('Test 9: Helper Functions with Provider Params');
+console.log('-'.repeat(70));
+
+failureCount = 0;
+
+allProviders.forEach(provider => {
+  const config = PROVIDER_TEST_CONFIG[provider.id];
+  const energyPerToken = getEnergyPerToken(provider.modelParams);
+  const numGPUs = getNumGPUs(provider.modelParams);
+
+  console.log(`  ${provider.name}:`);
+  console.log(`    Energy per token: ${energyPerToken.toExponential(4)} kWh/token`);
+  console.log(`    GPUs required: ${numGPUs}`);
+
+  // Validate values are reasonable
+  if (energyPerToken <= 0 || numGPUs <= 0) {
+    console.error(`    FAIL - Invalid values`);
+    failureCount++;
+  }
+
+  // Validate against expected GPU count if available
+  if (config && config.expectedGPUs && numGPUs !== config.expectedGPUs) {
+    console.error(`    FAIL - Expected ${config.expectedGPUs} GPUs, got ${numGPUs}`);
+    failureCount++;
+  }
+});
+
+if (failureCount === 0) {
+  console.log('  PASS - Helper functions work with all providers');
+} else {
+  console.error('  FAIL - Helper function errors');
+  process.exit(1);
+}
+console.log();
+
+// Test 10: Comparative Analysis
+console.log('Test 10: Comparative Analysis (100 tokens)');
+console.log('-'.repeat(70));
+
+console.log('  Provider Comparison:');
+
+// Display all providers
+allProviders.forEach(provider => {
+  const energy = energyResults[provider.id];
+  console.log(`    ${provider.name}: ${energy.totalEnergy.toFixed(4)} Wh (${energy.numGPUs} GPUs)`);
+});
+
+// Calculate ratios if we have multiple providers
+if (allProviders.length > 1) {
+  console.log();
+  console.log('  Energy Ratios (relative to first provider):');
+  const baseProvider = allProviders[0];
+  const baseEnergy = energyResults[baseProvider.id].totalEnergy;
+
+  allProviders.slice(1).forEach(provider => {
+    const energy = energyResults[provider.id].totalEnergy;
+    const ratio = (energy / baseEnergy).toFixed(2);
+    console.log(`    ${provider.name}/${baseProvider.name}: ${ratio}x`);
+  });
+}
+
+console.log('  PASS - Comparative analysis completed');
+console.log();
+
+// Summary
+console.log('='.repeat(70));
+console.log('ALL PROVIDER TESTS PASSED');
+console.log('='.repeat(70));
+console.log();
+console.log('Summary:');
+console.log('  - Provider registration working');
+console.log('  - Provider detection accurate');
+console.log('  - Provider lookup by ID working');
+console.log('  - Model parameters configured correctly');
+console.log('  - Token estimation functions working');
+console.log('  - Energy calculations work with all providers');
+console.log('  - DOM selectors defined for all providers');
+console.log('  - API patterns configured correctly');
+console.log('  - Helper functions work with provider params');
+console.log('  - Comparative analysis shows reasonable results');
+console.log();
+console.log('Provider Abstraction Layer is ready!');
+console.log();

--- a/test-refactoring.js
+++ b/test-refactoring.js
@@ -9,105 +9,144 @@ console.log('VERIFICATION: Issue #14 - Code Deduplication');
 console.log('='.repeat(70));
 console.log();
 
-// Import the shared module
+// Import the shared energy calculation module
 import {
   ECOLOGITS_CONSTANTS,
-  GPT5_PARAMS,
   calculateEnergyAndEmissions,
   getEnergyPerToken,
   getNumGPUs
 } from './energy-calculator.js';
 
-console.log('✅ Successfully imported energy-calculator.js as ES6 module');
+// Import provider configurations
+import { CHATGPT_PROVIDER, CLAUDE_PROVIDER } from './providers.js';
+
+console.log('Successfully imported energy-calculator.js and providers.js as ES6 modules');
 console.log();
 
-// Test 1: Check constants are defined (EcoLogits v0.9.x)
-console.log('Test 1: Checking constants...');
+// Provider test configurations
+const PROVIDER_TESTS = [
+  {
+    provider: CHATGPT_PROVIDER,
+    name: 'ChatGPT',
+    expected100tokens: { min: 0.23, max: 0.26 },
+    expectedGPUs: 16,
+    tokenRanges: [
+      { tokens: 10, min: 0.023, max: 0.026 },
+      { tokens: 100, min: 0.23, max: 0.26 },
+      { tokens: 1000, min: 2.3, max: 2.6 },
+      { tokens: 5000, min: 11.5, max: 13.0 }
+    ]
+  },
+  {
+    provider: CLAUDE_PROVIDER,
+    name: 'Claude',
+    expected100tokens: { min: 3.5, max: 3.7 },
+    expectedGPUs: 64,
+    tokenRanges: [
+      { tokens: 10, min: 0.34, max: 0.39 },
+      { tokens: 100, min: 3.5, max: 3.7 },
+      { tokens: 1000, min: 35, max: 37 },
+      { tokens: 5000, min: 175, max: 185 }
+    ]
+  }
+];
+
+// Test 1: Check constants and provider params are defined
+console.log('Test 1: Checking constants and provider params...');
 console.log(`  GPU_ENERGY_ALPHA: ${ECOLOGITS_CONSTANTS.GPU_ENERGY_ALPHA}`);
 console.log(`  GPU_ENERGY_BETA: ${ECOLOGITS_CONSTANTS.GPU_ENERGY_BETA}`);
 console.log(`  GPU_ENERGY_GAMMA: ${ECOLOGITS_CONSTANTS.GPU_ENERGY_GAMMA}`);
 console.log(`  BATCH_SIZE: ${ECOLOGITS_CONSTANTS.BATCH_SIZE}`);
-console.log(`  GPT-5 Total Params: ${GPT5_PARAMS.TOTAL_PARAMS / 1e9}B`);
-console.log(`  GPT-5 Active Params: ${GPT5_PARAMS.ACTIVE_PARAMS / 1e9}B`);
+console.log(`  ChatGPT Total Params: ${CHATGPT_PROVIDER.modelParams.totalParams / 1e9}B`);
+console.log(`  ChatGPT Active Params: ${CHATGPT_PROVIDER.modelParams.activeParams / 1e9}B`);
+console.log(`  Claude Total Params: ${CLAUDE_PROVIDER.modelParams.totalParams / 1e9}B`);
+console.log(`  Claude Active Params: ${CLAUDE_PROVIDER.modelParams.activeParams / 1e9}B`);
 
 if (ECOLOGITS_CONSTANTS.GPU_ENERGY_ALPHA === 1.1665273170451914e-06 &&
     ECOLOGITS_CONSTANTS.GPU_BITS === 16 &&
     ECOLOGITS_CONSTANTS.BATCH_SIZE === 64 &&
-    GPT5_PARAMS.TOTAL_PARAMS === 300e9) {
-  console.log('  ✅ PASS - All constants correct');
+    CHATGPT_PROVIDER.modelParams.totalParams === 300e9 &&
+    CLAUDE_PROVIDER.modelParams.totalParams === 2000e9) {
+  console.log('  PASS - All constants and provider params correct');
 } else {
-  console.log('  ❌ FAIL - Constants mismatch');
+  console.error('  FAIL - Constants or provider params mismatch');
   process.exit(1);
 }
 console.log();
 
-// Test 2: Test calculateEnergyAndEmissions function
+// Test 2: Test calculateEnergyAndEmissions function with all providers
 console.log('Test 2: Testing calculateEnergyAndEmissions...');
-const result100 = calculateEnergyAndEmissions(100);
-console.log(`  100 tokens: ${result100.totalEnergy.toFixed(4)} Wh`);
-console.log(`  CO2 emissions: ${result100.co2Emissions.toFixed(4)} g`);
-console.log(`  NumGPUs: ${result100.numGPUs}`);
 
-if (result100.totalEnergy >= 0.23 && result100.totalEnergy <= 0.26) {
-  console.log('  ✅ PASS - Calculation matches expected (~0.243 Wh)');
-} else {
-  console.log(`  ❌ FAIL - Expected ~0.243 Wh, got ${result100.totalEnergy.toFixed(4)} Wh`);
-  process.exit(1);
-}
+PROVIDER_TESTS.forEach(({ provider, name, expected100tokens }) => {
+  console.log(`  ${name}:`);
+  const result = calculateEnergyAndEmissions(100, provider.modelParams);
+  console.log(`    100 tokens: ${result.totalEnergy.toFixed(4)} Wh`);
+  console.log(`    CO2 emissions: ${result.co2Emissions.toFixed(4)} g`);
+  console.log(`    NumGPUs: ${result.numGPUs}`);
+
+  if (result.totalEnergy >= expected100tokens.min && result.totalEnergy <= expected100tokens.max) {
+    console.log(`    PASS - Calculation within expected range`);
+  } else {
+    console.error(`    FAIL - Expected ${expected100tokens.min}-${expected100tokens.max} Wh, got ${result.totalEnergy.toFixed(4)} Wh`);
+    process.exit(1);
+  }
+});
 console.log();
 
-// Test 3: Test helper functions
+// Test 3: Test helper functions with all providers
 console.log('Test 3: Testing helper functions...');
-const energyPerToken = getEnergyPerToken();
-const numGPUs = getNumGPUs();
-console.log(`  getEnergyPerToken(): ${energyPerToken.toExponential(4)} kWh/token`);
-console.log(`  getNumGPUs(): ${numGPUs} GPUs`);
 
-if (energyPerToken > 0 && numGPUs === 16) {
-  console.log('  ✅ PASS - Helper functions work correctly');
-} else {
-  console.log('  ❌ FAIL - Helper functions returned unexpected values');
-  process.exit(1);
-}
+PROVIDER_TESTS.forEach(({ provider, name, expectedGPUs }) => {
+  console.log(`  ${name}:`);
+  const energyPerToken = getEnergyPerToken(provider.modelParams);
+  const numGPUs = getNumGPUs(provider.modelParams);
+  console.log(`    getEnergyPerToken(): ${energyPerToken.toExponential(4)} kWh/token`);
+  console.log(`    getNumGPUs(): ${numGPUs} GPUs`);
+
+  if (energyPerToken > 0 && numGPUs === expectedGPUs) {
+    console.log(`    PASS - Helper functions work correctly`);
+  } else {
+    console.error(`    FAIL - Expected ${expectedGPUs} GPUs, got ${numGPUs}`);
+    process.exit(1);
+  }
+});
 console.log();
 
-// Test 4: Compare multiple token counts
+// Test 4: Compare multiple token counts across all providers
 console.log('Test 4: Testing various token counts...');
-const testCases = [
-  { tokens: 10, expectedMin: 0.023, expectedMax: 0.026 },
-  { tokens: 100, expectedMin: 0.23, expectedMax: 0.26 },
-  { tokens: 1000, expectedMin: 2.3, expectedMax: 2.6 },
-  { tokens: 5000, expectedMin: 11.5, expectedMax: 13.0 }
-];
 
 let allPassed = true;
-testCases.forEach(test => {
-  const result = calculateEnergyAndEmissions(test.tokens);
-  const passed = result.totalEnergy >= test.expectedMin && result.totalEnergy <= test.expectedMax;
-  const status = passed ? '✅' : '❌';
-  console.log(`  ${status} ${test.tokens} tokens: ${result.totalEnergy.toFixed(2)} Wh (expected ${test.expectedMin}-${test.expectedMax} Wh)`);
-  if (!passed) allPassed = false;
+PROVIDER_TESTS.forEach(({ provider, name, tokenRanges }) => {
+  console.log(`  ${name}:`);
+
+  tokenRanges.forEach(test => {
+    const result = calculateEnergyAndEmissions(test.tokens, provider.modelParams);
+    const passed = result.totalEnergy >= test.min && result.totalEnergy <= test.max;
+    const status = passed ? 'PASS' : 'FAIL';
+    console.log(`    ${status}: ${test.tokens} tokens: ${result.totalEnergy.toFixed(2)} Wh (expected ${test.min}-${test.max} Wh)`);
+    if (!passed) allPassed = false;
+  });
 });
 
 if (allPassed) {
-  console.log('  ✅ PASS - All token counts within expected ranges');
+  console.log('  PASS - All token counts within expected ranges for all providers');
 } else {
-  console.log('  ❌ FAIL - Some calculations out of range');
+  console.error('  FAIL - Some calculations out of range');
   process.exit(1);
 }
 console.log();
 
 // Summary
 console.log('='.repeat(70));
-console.log('✅ ALL TESTS PASSED - Refactoring successful!');
+console.log('ALL TESTS PASSED - Refactoring successful!');
 console.log('='.repeat(70));
 console.log();
 console.log('Summary:');
-console.log('  ✅ Shared module loads correctly as ES6 module');
-console.log('  ✅ Constants are properly defined');
-console.log('  ✅ calculateEnergyAndEmissions works correctly');
-console.log('  ✅ Helper functions work correctly');
-console.log('  ✅ Calculations match expected values');
+console.log('  - Shared module loads correctly as ES6 module');
+console.log('  - Constants and provider params properly defined');
+console.log('  - calculateEnergyAndEmissions works correctly for all providers');
+console.log('  - Helper functions work correctly for all providers');
+console.log('  - Calculations match expected values for ChatGPT and Claude');
 console.log();
 console.log('Next steps:');
 console.log('  1. Load the extension in Chrome (chrome://extensions)');

--- a/verify-fix.js
+++ b/verify-fix.js
@@ -86,7 +86,7 @@ testCases.forEach((test, index) => {
   console.log(`  Old v0.2 buggy:  ${buggy.totalEnergy.toFixed(4)} Wh`);
   console.log(`  New v0.9.x:      ${correct.totalEnergy.toFixed(4)} Wh`);
   console.log(`  Expected:        ${test.expectedMin.toFixed(3)} - ${test.expectedMax.toFixed(3)} Wh`);
-  console.log(`  ${passed ? '✅ PASS' : '❌ FAIL'}`);
+  console.log(`  ${passed ? 'PASS' : 'FAIL'}`);
   console.log();
 
   if (!passed) allTestsPassed = false;
@@ -123,9 +123,9 @@ console.log();
 
 console.log('='.repeat(70));
 if (allTestsPassed) {
-  console.log('✅ ALL TESTS PASSED - Fix is correct!');
+  console.log('ALL TESTS PASSED - Fix is correct!');
 } else {
-  console.log('❌ SOME TESTS FAILED - Review the implementation');
+  console.error('SOME TESTS FAILED - Review the implementation');
   process.exit(1);
 }
 console.log('='.repeat(70));


### PR DESCRIPTION
 ## Summary
  Adds support for Claude by implementing a provider abstraction layer that makes it easy to add new AI platforms.

![ai-impact-tracker-claude](https://github.com/user-attachments/assets/097f0147-4098-43fb-a580-a59fb78ee1ef)

  ## Changes
  - Created `providers.js` to define platform-specific configurations (designed for extensibility)
  - Updated `energy-calculator.js` to now require explicit model params instead of defaulting to ChatGPT
  - Updated `content.js`, `popup.js`, and `background.js` to use the provider abstraction
  - Updated the UI text to be platform-agnostic (minor updates)

  ## Energy Calculations
  - ChatGPT (GPT-5): 60B active params --> ~0.24 Wh per 100 tokens (unchanged)
  - Claude (3 Opus proxy): 400B active params --> ~3.61 Wh per 100 tokens (based on [EcoLogits estimates](https://ecologits.ai/latest/methodology/proprietary_models/))

  ## Unit Testing
  - Parameterised existing unit tests for Claude coverage (written to be extensible for further providers)
  - Added new unit tests for provider management
 
  ## Breaking Change
This change updates the storage key from `chatgptLogs` to `aiChatLogs`, which will reset existing user data on upgrade. This was deemed acceptable for early-stage project with few users - but open to input!

  ## Documentation
  - Updated README.md to reflect Claude support
  - Updated CLAUDE.md with provider architecture details
  
  ## Manual Testing

- [x] Code blocks are captured in token count and reflected in the energy estimate
- [x] Energy estimate scales proportionally for long (1000+ word) responses
- [x] Very short responses show small but non-zero energy estimates 
- [x] Complex formatting like tables and lists are accounted for in energy estimates
- [x] Many back-and-forth exchanges result in multiple message entries in the pop up
- [x] Editing a previous message to Claude increases the energy estimate
- [x] Different Claude conversations contribute to the same energy estimate
- [x] Popup stats are displayed as-expected
- [x] Both Claude and ChatGPT conversations contribute to the same energy estimate
- [x] The energy estimate persists across page refreshes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended real-time energy tracking to support Claude alongside ChatGPT
  * Energy and emissions calculations now adapt to different AI provider models
  * Added Claude.ai as a newly supported platform

* **Documentation & UX**
  * Updated global scale comparisons and messaging to reflect multi-provider AI chat support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->